### PR TITLE
Move script tag inside body element in explore.html

### DIFF
--- a/_layouts/explore.html
+++ b/_layouts/explore.html
@@ -99,7 +99,6 @@
 
     </div>
 {% include site_footer.html %}
-</body>
 <script>
 
     /**
@@ -282,4 +281,5 @@
     }
     
     </script>
+</body>
 </html>

--- a/_layouts/explore.html
+++ b/_layouts/explore.html
@@ -98,8 +98,8 @@
         </div>
 
     </div>
-{% include site_footer.html %}
-<script>
+    {% include site_footer.html %}
+    <script>
 
     /**
      * resetListItemsVisibility(numOfFilters) 


### PR DESCRIPTION
  ## What Changed?                                                                                                                                                                                          
  Updated explore.html to move the `</body>` closing tag after the `</script>` tag
                                                                           
  ## Why Did It Change?
  To fix the invalid HTML structure. The `<script>` block was incorrectly placed outside the `<body>` element, which violates HTML standards. Scripts should be contained within `<body>` for proper structure and consistent browser behavior.