### PR TITLE
Removed 'SEARCH' text and updated search bar suggestion

### DIFF
--- a/_layouts/hmovie-home.html
+++ b/_layouts/hmovie-home.html
@@ -19,10 +19,9 @@
                 <div class="text_over_image" >
                     <h1 class="hmovie_title black_shadow">Hmovie</h1>
                     <p class="sub_title black_shadow">The Largest Digital Hmong Movie Database</p>
-                    <p class="black_shadow">SEARCH FOR A MOVIE</p> 
                     <form action="{{site.baseurl}}/search/" id="home_searchbar" class="black_div_shadow" method="get" aria-label="Search Bar">
                         <span class="search_home_icon" style="background-image: url('{{ "/assets/images/search.jpeg" | relative_url }}')" aria-label="Search Icon"></span>
-                        <input type="text" class="search_home_input" name="q" aria-label="Search bar field" placeholder="search" required/>
+                        <input type="text" class="search_home_input" name="q" aria-label="Search bar field" placeholder="Search for a movie or actor..." required/>
                     </form>
 
                 </div>


### PR DESCRIPTION
## What Changed
Removed the "SEARCH FOR A MOVIE" text and updated the search bar suggestion from 'search' to 'Search for a movie or actor..."

## Why Did It Change
To reduce redundancy and provide clarity to what users can search with the search bar

Original: 
<img width="1216" height="530" alt="Screenshot 2026-02-11 at 12 37 07 PM" src="https://github.com/user-attachments/assets/0c6eeb8a-6b08-486c-96d4-9fa6aaf08098" />

New: 
<img width="1407" height="733" alt="Screenshot 2026-02-11 at 12 39 01 PM" src="https://github.com/user-attachments/assets/3bbf21b9-4606-4fae-ae5d-110d81c55e6e" />




