### PR TITLE
remove duplicate <head> tag from site_header.html

### DIFF
--- a/_includes/site_header.html
+++ b/_includes/site_header.html
@@ -1,6 +1,3 @@
-<head>
-    <!-- <link href="//fonts.googleapis.com/css?family=Maven+Pro" rel="stylesheet" type="text/css"> -->
-</head>
 <header class="site_header">
     <a href="{{ '/' | relative_url }}" class="home_button"  aria-label="Link to home page">Hmovie</a>
     <!-- <form action="{{site.baseurl}}/search/" method="get" id="header_searchbar">


### PR DESCRIPTION
## What Changed?

- Removed the duplicate `<head>` tag from `_includes/site_header.html`
- Deleted the unused `<head>` block (contained a comment for Google Fonts link)

## Why Did It Change?

- The `<head>` element already exists in the layout file
- A duplicate `<head>` creates invalid HTML and may cause cross-browser rendering issues
