### PR TITLE
  Add GA4 contribute_form_click event tracking

### DIFF
--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -22,19 +22,19 @@
                     <h2>Contribution Options</h2>
                     <div class="three_columns" >
                         <div>
-                            <a href="https://forms.gle/tyC7acNTDTUhufvQA" target="_blank" class="clickable_link_block" aria-label="Link to a Google Form to Add Movies or Actors">
+                            <a href="https://forms.gle/tyC7acNTDTUhufvQA" target="_blank" class="clickable_link_block" data-contribute="add_movie_actor" aria-label="Link to a Google Form to Add Movies or Actors">
                                 <img src="{{ site.url }}{{ site.baseurl }}/assets/images/add.png" class="circle_img contribute_button" alt="Icon of a character with a plus button">
                                 <p>Add an actor or movie</p>
                             </a>
                         </div>
                         <div>
-                            <a href="https://forms.gle/tNbZFYJhX5boqLct6" target="_blank" class="clickable_link_block" aria-label="Link to a Google Form to Edit Movies or Actors">
+                            <a href="https://forms.gle/tNbZFYJhX5boqLct6" target="_blank" class="clickable_link_block" data-contribute="edit_movie_actor" aria-label="Link to a Google Form to Edit Movies or Actors">
                                 <img src="{{ site.url }}{{ site.baseurl }}/assets/images/edit.png" class="circle_img contribute_button" alt="Icon of a pencil to edit">
                                 <p>Edit an existing actor or movie</p>
                             </a>
                         </div>
                         <div>
-                            <a href="https://forms.gle/yyncvdUPU81637j57" target="_blank" class="clickable_link_block" aria-label="Link to a Google Form to Contribute">
+                            <a href="https://forms.gle/yyncvdUPU81637j57" target="_blank" class="clickable_link_block" data-contribute="report_bug_join" aria-label="Link to a Google Form to Contribute">
                                 <img src="{{ site.url }}{{ site.baseurl }}/assets/images/code.png" class="circle_img contribute_button" alt="Icon of a two curly brackets to represent code">
                                 <p>Report a bug or Join the Code!</p>
                             </a>

--- a/assets/js/analytics-events.js
+++ b/assets/js/analytics-events.js
@@ -1,5 +1,4 @@
 document.addEventListener("DOMContentLoaded", function () {
-  // --- Search Form Tracking ---
   var headerSearch = document.getElementById("header_searchbar");
   var homeSearch = document.getElementById("home_searchbar");
 
@@ -22,4 +21,13 @@ document.addEventListener("DOMContentLoaded", function () {
       });
     });
   }
+
+  document.querySelectorAll("[data-contribute]").forEach(function (link) {
+    link.addEventListener("click", function () {
+      gtag("event", "contribute_form_click", {
+        form_type: this.dataset.contribute,
+        link_url: this.href,
+      });
+    });
+  });
 });


### PR DESCRIPTION
## What Changed
- Added `data-contribute` attributes to Google Form links (`add_movie_actor`, `edit_movie_actor`, `report_bug_join`)
- Added shared click listener in `analytics-events.js` to fire `contribute_form_click` with `form_type` and `link_url`

## Why It Changed
- Previously, there was no tracking for the contribute form clicks
- Enables measurement of contributor engagement and form usage