### PR TITLE
Fix invalid Liquid syntax causing build errors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## What Changed?
+
+-
+
+## Why Did It Change?
+
+-

--- a/_layouts/404-error.html
+++ b/_layouts/404-error.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title> {{%page.title%}} </title>
+        <title> {{ page.title }} </title>
         <link rel="stylesheet" href="{{ 'assets/css/styles.css' | relative_url }}">
         <link rel="icon" type="image/x-icon" href="{{ site.url }}{{ site.baseurl }}/assets/images/fav-icon.png">
         {% if site.google_analytics and jekyll.environment == 'production' %}

--- a/_layouts/about.html
+++ b/_layouts/about.html
@@ -3,7 +3,7 @@
 
     <head>
         <meta charset="UTF-8">
-        <title> {{%page.title%}} </title>
+        <title> {{ page.title }} </title>
         <link rel="stylesheet" href="{{ 'assets/css/styles.css' | relative_url }}">
         <link rel="icon" type="image/x-icon" href="{{ site.url }}{{ site.baseurl }}/assets/images/fav-icon.png">
         {% if site.google_analytics and jekyll.environment == 'production' %}

--- a/_layouts/cast.html
+++ b/_layouts/cast.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title> {{ %page.title% }} </title>
+        <title> {{ page.title }} </title>
         <link rel="stylesheet" href="{{ 'assets/css/styles.css' | relative_url }}">
         <link rel="icon" type="image/x-icon" href="{{ site.url }}{{ site.baseurl }}/assets/images/fav-icon.png">
         {% if site.google_analytics and jekyll.environment == 'production' %}

--- a/_layouts/contribute.html
+++ b/_layouts/contribute.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title> {{%page.title%}} </title>
+        <title> {{ page.title }} </title>
         <link rel="stylesheet" href="{{ 'assets/css/styles.css' | relative_url }}">
         <link rel="icon" type="image/x-icon" href="{{ site.url }}{{ site.baseurl }}/assets/images/fav-icon.png">
         {% if site.google_analytics and jekyll.environment == 'production' %}

--- a/_layouts/explore.html
+++ b/_layouts/explore.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title> {{%page.title%}} </title>
+    <title> {{ page.title }} </title>
     <link rel="stylesheet" href="{{ 'assets/css/styles.css' | relative_url }}">
     <link rel="icon" type="image/x-icon" href="{{ site.url }}{{ site.baseurl }}/assets/images/fav-icon.png">
     {% if site.google_analytics and jekyll.environment == 'production' %}
@@ -25,10 +25,10 @@
                 <ul id="movies_list" class="inner_shadow" aria-label="List of movies">
                     {% assign sortedPosts = site.categories.movie | sort: 'title' %}
                     {% for movie in sortedPosts %}
-                        <li data-filter-data="{{%movie.year%}} {{%movie.release_type%}} {{movie.genre}} {{movie.video_link}}" aria-label="{{movie.title}}">
+                        <li data-filter-data="{{ movie.year }} {{ movie.release_type }} {{movie.genre}} {{movie.video_link}}" aria-label="{{movie.title}}">
                             <a href="{{ movie.permalink | relative_url }}" aria-label="Link to {{movie.title}}" data-type="{% for person in movie.cast %}{{ person.name }}{% if forloop.last == false %}, {% endif %}{% endfor %}">
                                 <div class="explore_movie_li" style="background-image: url('{{ movie.thumbnail | relative_url }}')" aria-label="Movie Thumbnail"></div>
-                                <div>{{ %movie.title% }}</div>
+                                <div>{{ movie.title }}</div>
                             </a>
                         </li>
                     {% endfor%}

--- a/_layouts/hmovie-home.html
+++ b/_layouts/hmovie-home.html
@@ -30,10 +30,10 @@
                 <p class="center_text">EXPLORE THE CURRENT COLLECTION</p>
                 <ul class="home_featured_movies" aria-label="List of Featured movies on homepage">
                 {% for movie in site.categories.front %}
-                        <li data-filter-data="{{%movie.year%}} {{%movie.release-type%}} {{movie.genre}}" aria-label="{{movie.title}}">
+                        <li data-filter-data="{{ movie.year }} {{ movie.release-type }} {{movie.genre}}" aria-label="{{movie.title}}">
                             <a href="{{ movie.permalink | relative_url }}">
                                  <div class="home_movie_li" style="background-image: url('{{ movie.thumbnail | relative_url }}')"></div>
-                                <div>{{ %movie.title% }}</div>
+                                <div>{{ movie.title }}</div>
                             </a>
                         </li>
                 {% endfor %}

--- a/_layouts/legal.html
+++ b/_layouts/legal.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title> {{%page.title%}} </title>
+        <title> {{ page.title }} </title>
         <link rel="stylesheet" href="{{ 'assets/css/styles.css' | relative_url }}">
         <link rel="icon" type="image/x-icon" href="{{ site.url }}{{ site.baseurl }}/assets/images/fav-icon.png">
         {% if site.google_analytics and jekyll.environment == 'production' %}

--- a/_layouts/movie-video-data.html
+++ b/_layouts/movie-video-data.html
@@ -3,7 +3,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title> {{ %page.title% }} </title>
+        <title> {{ page.title }} </title>
         <link rel="stylesheet" href="{{ 'assets/css/styles.css' | relative_url }}">
         <link rel="icon" type="image/x-icon" href="{{ site.url }}{{ site.baseurl }}/assets/images/fav-icon.png">
         {% if site.google_analytics and jekyll.environment == 'production' %}
@@ -18,7 +18,7 @@
     <!-- Movie Video PopUp -->
     <div id="black_bg" onclick="closePopUp()">
         <!-- <button id="close_popup_button">x</button> -->
-        <a href="{{%page.video_link%}}" target="_blank" aria-label="Link to view Movie on external site"> Link </a>
+        <a href="{{ page.video_link }}" target="_blank" aria-label="Link to view Movie on external site"> Link </a>
         <div id="movie_popup"></div>
     </div>
 
@@ -26,7 +26,7 @@
     <div class="center_content"> 
         <!-- Put title and button beside one another-->
         <div class="movie_videoview_title">
-            <h1 alt="Movie Title"> {{ %page.title% }} </h1>
+            <h1 alt="Movie Title"> {{ page.title }} </h1>
             {% include display_play_movie_button.html %}
             <!-- <button type="button" class="clear_filters_button" onclick="triggerPopUp()"> Watch Movie </button> -->
         </div>
@@ -39,17 +39,17 @@
                 <img src="{{ site.url }}{{ site.baseurl }}{{ page.thumbnail}}" alt="{{page.title}} Movie Poster" width="100%" class="rounded_img">
                 <div class="movie_metadata inner_shadow margin_top">
                     <p class="meta_data_type">Production Year:</p>
-                    <p>{{%page.year%}}</p>
+                    <p>{{ page.year }}</p>
                     <p class="meta_data_type">Producer(s):</p>
-                    <p>{{%page.producer%}}</p>
+                    <p>{{ page.producer }}</p>
                     <p class="meta_data_type">Writer(s):</p>
-                    <p>{{%page.writer%}}</p>
+                    <p>{{ page.writer }}</p>
                     <p class="meta_data_type">Publisher:</p>
-                    <p>{{%page.publishing_company}}</p>
+                    <p>{{ page.publishing_company }}</p>
                     <p class="meta_data_type"> Release Type:</p>
-                    <p>{{%page.release_type%}}</p>
+                    <p>{{ page.release_type }}</p>
                     <!-- <p class="meta_data_type"> Storage Location:</p>
-                    <p>{{%page.storage%}}</p> -->
+                    <p>{{ page.storage }}</p> -->
                 </div>
             </div>  
 
@@ -60,7 +60,7 @@
             </div>
             {% else %}
             <div>
-                <p> {{ %page.synopsis%}} </p>
+                <p> {{ page.synopsis }} </p>
                 
                 {% include display_page_cast.html %}
                 

--- a/_layouts/new-search.html
+++ b/_layouts/new-search.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <title> {{%page.title%}} </title>
+    <title> {{ page.title }} </title>
     <link rel="stylesheet" href="{{ 'assets/css/styles.css' | relative_url }}">
     <link rel="icon" type="image/x-icon" href="{{ site.url }}{{ site.baseurl }}/assets/images/fav-icon.png">
     {% if site.google_analytics and jekyll.environment == 'production' %}
@@ -23,7 +23,7 @@
                     <a href="{{actor.permalink | relative_url}}" aria-label="Link to {{actor.title}} page">
                         <div class="side_by_side">
                             <img src="{{actor.thumbnail | relative_url}}" class="circle_img" alt="{{actor.title}} Thumbnail" height="80px">
-                            <p>{{ %actor.title% }}</p>
+                            <p>{{ actor.title }}</p>
                         </div>
                     </a>
                 </li>
@@ -38,7 +38,7 @@
                     <a href="{{ movie.permalink | relative_url }}">
                         <!-- <img src="{{movie.thumbnail}}" alt="movie link" class="rounded_img" width="100%"> -->
                         <div class="explore_movie_li" style="background-image: url('{{ movie.thumbnail | relative_url }}')" aria-label="{{movie.title}} Thumbnail"></div>
-                        <div>{{ %movie.title% }}</div>
+                        <div>{{ movie.title }}</div>
                     </a>
                 </li>
             {% endfor%}


### PR DESCRIPTION
 ## What Changed?                                                                                                                                                                                                  
                                                                                                                                                                                                                 
  - Removed stray % characters from Liquid `{{ }}` tags in 9 layout files                                                                                                                                          
  - Fixed output syntax for page metadata, movie details, and actor names                                                                                                                                        
  - Added a GitHub PR template with "What Changed?" and "Why Did It Change?" sections                                                                                                                            
                                                                                                                                                                                                                 
  ## Why Did It Change?                                                                                                                                                                                             

  - Invalid Liquid syntax `({{%var%}})` was causing Jekyll build failures
  - Affected pages were not rendering variable content (titles, years, etc.)
  - PR template standardizes how contributors describe their changes