### PR TITLE
Remove unnecessary styles from .center_content

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -260,8 +260,6 @@ body {
     margin-right: 10%;
     margin-bottom: 5%;
     padding: 0.5rem;
-    min-height: calc(100vh - 267px);
-    // background-color: antiquewhite;
 }
 
 .black_div_shadow {


### PR DESCRIPTION
## What Changed?                                                                                                         
                                                                                                                        
  - Removed the min-height constraint from the .center_content container                                                
  - Removed a commented-out background-color style from .center_content                                                 
                                                                                                                        
##  Why Did It Change?                                                                                                    
                                                                                                                        
  - The min-height: calc(100vh - 267px) was constraining the content area height
