### PR TITLE
Use flexbox sticky footer instead of hardcoded min-height

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -253,9 +253,13 @@ button {
 
 body {
     margin: 0px;
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
 }
 
 .center_content {
+    flex: 1;
     margin-left: 10%;
     margin-right: 10%;
     margin-bottom: 5%;


### PR DESCRIPTION
## What Changed?                                                                                       
                                                                                                      
  - Body element now uses flexbox with a column layout and full viewport height                       
  - The main content area (.center_content) grows to fill available vertical space via flex: 1        
                                                                                                      
 ## Why Did It Change?                                                                                  
                                                                                                      
  - The previous min-height: calc(100vh - 267px) was removed but not replaced, leaving the footer   
  floating mid-page on short-content pages
  - A flexbox sticky footer is a modern, maintainable approach that doesn't rely on hardcoded pixels
  values for header/footer heights

## Screenshot

- With this change, the footer will remain fixed at the bottom of the viewport, regardless of the page's content height:
<img width="1561" height="1003" alt="image" src="https://github.com/user-attachments/assets/023a6c67-03b8-4ff0-be0d-99d3040d020e" />

- Without this change, the site footer will sit directly below the page content, leaving empty space at the bottom of the viewport: 
<img width="1525" height="1075" alt="image" src="https://github.com/user-attachments/assets/e27c6c40-6d35-4765-921a-0282103deafd" />


