### PR TITLE
Added Facebook to Footer

### DIFF
--- a/_includes/site_footer.html
+++ b/_includes/site_footer.html
@@ -31,8 +31,9 @@
         <a href="{{ '/terms_of_use' | relative_url }}" aria-label="Link to Terms of Use Page">Terms of Use</a>
         <a href="{{ '/privacy_policy' | relative_url }}" aria-label="Link to Privacy Policy Page">Privacy Policy</a>
     </div>
-    <div>
+    <div class="footer_stack_items">
         <h1 class="footer_sub_title">Contact</h1>
         <a href="https://forms.gle/wXPr6YyNa5qmJC9u7" target="_blank" aria-label="Link to Contact Form">Contact Form</a>
+        <a href="https://www.facebook.com/profile.php?id=61571725514010" target="_blank" aria-label="Hmovie Facebook Page">Facebook</a>
     </div>
 </footer>


### PR DESCRIPTION
## What Changed?

A link to the Hmovie Facebook was added to the Footer under the 'Contact' section.
<img width="1248" height="660" alt="Screenshot 2026-03-17 at 7 47 55 PM" src="https://github.com/user-attachments/assets/92812ba3-7e86-420c-8acb-59ef6e74e97a" />


## Why Did It Change?
The link was added to promote social engagement and allow Hmovie to be more accessible to users

NOTE: The Facebook link has been added as text with hyperlink. When we do site UI overhaul, we can improve how the social media page is shared, but keeping this for now.
