### PR TITLE
Fix long URLs when links are opened from Facebook

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,4 +6,22 @@
     {% if site.google_analytics and jekyll.environment == 'production' %}
         {% include analytics.html %}
     {% endif %}
+    <script>
+        function removeTrackingParams() {
+            const TRACKING_PARAMS = ['fbclid', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content'];
+            const params = new URLSearchParams(window.location.search);
+            const hasTracking = TRACKING_PARAMS.some(p => params.has(p));
+
+            if (!hasTracking) return;
+
+            TRACKING_PARAMS.forEach(param => params.delete(param));
+
+            const query = params.toString() ? '?' + params.toString() : '';
+            const cleanUrl = window.location.pathname + query + window.location.hash;
+            
+            history.replaceState(null, '', cleanUrl);
+        }
+
+        removeTrackingParams();
+    </script>
 </head>


### PR DESCRIPTION
## What Changed?
  - Added an inline script to <head> that strips Facebook (fbclid) and UTM tracking parameters (utm_source, utm_medium, utm_campaign, utm_term, utm_content) from the browser URL on page load                                                                                                            
  - The script uses history.replaceState to silently clean the URL without triggering a redirect or page reload
                                                                                                                                                                                                                          
## Why Did It Change?                                                                                                                                                                                                                        
                                                                                                                                                                                                                                            
  - Links shared or clicked from Facebook append a long fbclid parameter that makes URLs visually ugly and confusing for users                                                                                                               