### PR TITLE
Pin sass-embedded to 1.77.0 to fix build on Ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ source "https://rubygems.org"
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 gem "jekyll", "~> 4.3.4"
+gem "sass-embedded", "1.77.0"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
-    bigdecimal (3.1.8)
+    bigdecimal (4.1.0)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
     em-websocket (0.5.3)
@@ -14,32 +14,14 @@ GEM
     ffi (1.17.0-aarch64-linux)
     ffi (1.17.0-aarch64-linux-musl)
     ffi (1.17.0-arm-linux)
-    ffi (1.17.0-arm-linux-musl)
     ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86-linux)
-    ffi (1.17.0-x86-linux-musl)
     ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux)
     ffi (1.17.0-x86_64-linux-musl)
     forwardable-extended (2.6.0)
-    google-protobuf (4.29.1)
+    google-protobuf (4.34.1)
       bigdecimal
-      rake (>= 13)
-    google-protobuf (4.29.1-aarch64-linux)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.29.1-arm64-darwin)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.29.1-x86-linux)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.29.1-x86_64-darwin)
-      bigdecimal
-      rake (>= 13)
-    google-protobuf (4.29.1-x86_64-linux)
-      bigdecimal
-      rake (>= 13)
+      rake (~> 13.3)
     http_parser.rb (0.8.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
@@ -83,88 +65,73 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (6.0.1)
-    rake (13.2.1)
+    rake (13.3.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.4)
     rouge (4.5.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.82.0)
-      google-protobuf (~> 4.28)
-      rake (>= 13)
-    sass-embedded (1.82.0-aarch64-linux)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-aarch64-linux-android)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-aarch64-linux-musl)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-aarch64-mingw-ucrt)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-arm-linux)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-arm-linux-androideabi)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-arm-linux-musleabihf)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-arm64-darwin)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-riscv64-linux)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-riscv64-linux-android)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-riscv64-linux-musl)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-x86-cygwin)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-x86-linux)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-x86-linux-android)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-x86-linux-musl)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-x86-mingw-ucrt)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-x86_64-cygwin)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-x86_64-darwin)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-x86_64-linux)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-x86_64-linux-android)
-      google-protobuf (~> 4.28)
-    sass-embedded (1.82.0-x86_64-linux-musl)
-      google-protobuf (~> 4.28)
+    sass-embedded (1.77.0)
+      google-protobuf (>= 3.25, < 5.0)
+      rake (>= 13.0.0)
+    sass-embedded (1.77.0-aarch64-linux)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-aarch64-linux-android)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-aarch64-linux-musl)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-aarch64-mingw-ucrt)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-arm-linux)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-arm-linux-androideabi)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-arm-linux-musleabihf)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-arm64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-riscv64-linux)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-riscv64-linux-android)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-riscv64-linux-musl)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-x64-mingw-ucrt)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-x86_64-darwin)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-x86_64-linux)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-x86_64-linux-android)
+      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-x86_64-linux-musl)
+      google-protobuf (>= 3.25, < 5.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2026.1)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.6.0)
+    wdm (0.2.0)
     webrick (1.9.1)
 
 PLATFORMS
-  aarch64-linux
   aarch64-linux
   aarch64-linux-android
   aarch64-linux-musl
   aarch64-mingw-ucrt
   arm-linux
-  arm-linux
   arm-linux-androideabi
-  arm-linux-musl
   arm-linux-musleabihf
   arm64-darwin
   riscv64-linux
   riscv64-linux-android
   riscv64-linux-musl
   ruby
-  x86-cygwin
-  x86-linux
-  x86-linux
-  x86-linux-android
-  x86-linux-musl
-  x86-mingw-ucrt
-  x86_64-cygwin
+  x64-mingw-ucrt
   x86_64-darwin
-  x86_64-linux
   x86_64-linux
   x86_64-linux-android
   x86_64-linux-musl
@@ -174,6 +141,7 @@ DEPENDENCIES
   jekyll (~> 4.3.4)
   jekyll-feed (~> 0.12)
   minima (~> 2.5)
+  sass-embedded (= 1.77.0)
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1)


### PR DESCRIPTION
## What Changed?

  - sass-embedded explicitly pinned to version 1.77.0 in the Gemfile
  - Lockfile updated to reflect the pinned version and cleaned up duplicate/removed platform entries

##  Why Did It Change?

  - sass-embedded 1.82.0 (previously locked) was yanked from RubyGems, causing CI installs to fail
  - All versions from 1.77.1 onward require Ruby >= 3.2, but the project runs Ruby 3.1.2
  - 1.77.0 is the last release compatible with Ruby 3.1.x, making it the safest fix without a Ruby upgrade