### PR TITLE
dynamically resolve sass-embedded to avoid yanked versions

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+      - name: Update sass-embedded to latest non-yanked version
+        run: bundle update sass-embedded
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ source "https://rubygems.org"
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
 gem "jekyll", "~> 4.3.4"
-gem "sass-embedded", "1.77.0"
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
 gem "minima", "~> 2.5"
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and


### PR DESCRIPTION
## What Changed?       

  - Removed the explicit sass-embedded version pin from the Gemfile
  - Added a bundle update sass-embedded step to the CI workflow before the Jekyll build
                                              
##  Why Did It Change?                                                                                                                                                                                                                        
   
  - CI was failing because the Gemfile.lock referenced sass-embedded with the old Linux platform name (x86_64-linux), but the gem is now published under x86_64-linux-gnu                                                                   
  - Bundler couldn't find the locked version on RubyGems because it was looking for the wrong platform gem
  - Pinning a specific version is fragile — platform renames and yanked releases will break CI again without warning                                                                                                                        
  - Dynamically resolving sass-embedded at build time ensures CI always installs a compatible, available version for its Ruby and platform  