### PR TITLE
Fix/ci bundle update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build Jekyll site
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: false
+
+      - name: Install dependencies
+        run: bundle update sass-embedded && bundle install
+
+      - name: Build site
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -38,13 +38,12 @@ jobs:
         uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
         with:
           ruby-version: '3.2' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          cache-version: 0 # Increment this number if you need to re-download cached gems
+          bundler-cache: false
+      - name: Install dependencies
+        run: bundle update sass-embedded && bundle install
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-      - name: Update sass-embedded to latest non-yanked version
-        run: bundle update sass-embedded
       - name: Build with Jekyll
         # Outputs to the './_site' directory by default
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,7 +141,6 @@ DEPENDENCIES
   jekyll (~> 4.3.4)
   jekyll-feed (~> 0.12)
   minima (~> 2.5)
-  sass-embedded (= 1.77.0)
   tzinfo (>= 1, < 3)
   tzinfo-data
   wdm (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,29 +1,30 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.8.9)
+      public_suffix (>= 2.0.2, < 8.0)
     bigdecimal (4.1.0)
     colorator (1.1.0)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.6)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
-    ffi (1.17.0)
-    ffi (1.17.0-aarch64-linux)
-    ffi (1.17.0-aarch64-linux-musl)
-    ffi (1.17.0-arm-linux)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux)
-    ffi (1.17.0-x86_64-linux-musl)
+    ffi (1.17.4)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86_64-darwin)
     forwardable-extended (2.6.0)
     google-protobuf (4.34.1)
       bigdecimal
       rake (~> 13.3)
-    http_parser.rb (0.8.0)
-    i18n (1.14.6)
+    google-protobuf (4.34.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.34.1-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    http_parser.rb (0.8.1)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     jekyll (4.3.4)
       addressable (~> 2.4)
@@ -43,20 +44,22 @@ GEM
       webrick (~> 1.7)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-sass-converter (3.0.0)
-      sass-embedded (~> 1.54)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.5.1)
-      rexml (>= 3.3.9)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.4)
-    listen (3.9.0)
+    listen (3.10.0)
+      logger
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
     mercenary (0.4.0)
     minima (2.5.2)
       jekyll (>= 3.5, < 5.0)
@@ -64,77 +67,30 @@ GEM
       jekyll-seo-tag (~> 2.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (6.0.1)
+    public_suffix (6.0.2)
     rake (13.3.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.4)
-    rouge (4.5.1)
+    rouge (4.7.0)
     safe_yaml (1.0.5)
-    sass-embedded (1.77.0)
-      google-protobuf (>= 3.25, < 5.0)
-      rake (>= 13.0.0)
-    sass-embedded (1.77.0-aarch64-linux)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-aarch64-linux-android)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-aarch64-linux-musl)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-aarch64-mingw-ucrt)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-arm-linux)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-arm-linux-androideabi)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-arm-linux-musleabihf)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-arm64-darwin)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-riscv64-linux)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-riscv64-linux-android)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-riscv64-linux-musl)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-x64-mingw-ucrt)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-x86_64-darwin)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-x86_64-linux)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-x86_64-linux-android)
-      google-protobuf (>= 3.25, < 5.0)
-    sass-embedded (1.77.0-x86_64-linux-musl)
-      google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.98.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.98.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.98.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    tzinfo (2.0.6)
-      concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2026.1)
-      tzinfo (>= 1.0.0)
     unicode-display_width (2.6.0)
-    wdm (0.2.0)
-    webrick (1.9.1)
+    webrick (1.9.2)
 
 PLATFORMS
-  aarch64-linux
-  aarch64-linux-android
-  aarch64-linux-musl
-  aarch64-mingw-ucrt
-  arm-linux
-  arm-linux-androideabi
-  arm-linux-musleabihf
   arm64-darwin
-  riscv64-linux
-  riscv64-linux-android
-  riscv64-linux-musl
   ruby
-  x64-mingw-ucrt
   x86_64-darwin
-  x86_64-linux
-  x86_64-linux-android
-  x86_64-linux-musl
 
 DEPENDENCIES
   http_parser.rb (~> 0.6.0)
@@ -146,4 +102,4 @@ DEPENDENCIES
   wdm (~> 0.1)
 
 BUNDLED WITH
-   2.5.23
+   2.6.9


### PR DESCRIPTION
 ## What Changed?
                                                                                                                                                                                                                                            
  - Added a new CI workflow that validates Jekyll builds on every PR to main
  - Updated the deploy workflow to run bundle update sass-embedded before installing, bypassing the frozen lock file                                                                                                                        
  - Regenerated Gemfile.lock from scratch, updating ffi (1.17.4), sass-embedded (1.98.0), and several other dependencies                                                                                                                    
                                                                                                                                                                                                                                            
 ## Why Did It Change?                                                                                                                                                                                                                        
                                                                                                                                                                                                                                            
  - PRs had no automated build validation, so broken builds only surfaced after merging to main                                                                                                                                             
  - The lock file had a stale sass-embedded = 1.77.0 direct dependency pin left over from a previous fix, which caused CI to fail with a spurious ffi resolution error
  - ffi 1.17.0 and other locked platform-specific gem variants were no longer resolvable by the CI runner, requiring a full lock file regeneration   